### PR TITLE
Fix typo in RemoveCustomizerItems.php

### DIFF
--- a/src/Module/RemoveCustomizerItems.php
+++ b/src/Module/RemoveCustomizerItems.php
@@ -35,7 +35,7 @@ class RemoveCustomizerItems extends Instance
 
     protected function hook()
     {
-      add_action('customize_register', [$this, 'removeCustomizer']);
+      add_action('customize_register', [$this, 'removeCustomizerItems']);
     }
 
     public function removeCustomizerItems($wp_customize)


### PR DESCRIPTION
I believe the method name is misspelt: Throws a Warning: call_user_func_array() expects parameter 1 to be a valid callback... when you use this module and navigate to the customizer in wp-admin.